### PR TITLE
Update files for JURECA

### DIFF
--- a/machines/fzj/jureca/cpu.sh
+++ b/machines/fzj/jureca/cpu.sh
@@ -1,12 +1,13 @@
-BASE=/homea/jias41/jias4102/USQCD/jureca
+BASE=$HOME/USQCD/jureca/cpu
 
 HOST=x86_64-linux-gnu
 
 module purge
-module load GCC/7.2.0 ParaStationMPI/5.2.0-1 HDF5/1.8.19 FFTW/3.3.6
+module load GCC/8.2.0 ParaStationMPI/5.2.1-1 HDF5/1.10.1 FFTW/3.3.8 CMake
 
-INSTALL[hdf5]=/usr/local/software/jureca/Stages/2017b/software/HDF5/1.8.19-gpsmpi-2017b
-INSTALL[fftw]=/usr/local/software/jureca/Stages/2016b/software/FFTW/3.3.6-gpsmpi-2017b
+DIR[SOURCE]=$HOME/USQCD/jureca/source
+INSTALL[hdf5]=/usr/local/software/jureca/Stages/2018b/software/HDF5/1.10.1-gpsmpi-2018b
+INSTALL[fftw]=/usr/local/software/jureca/Stages/2018b/software/FFTW/3.3.8-gpsmpi-2018b
 
 GET[libxml2]='curl ftp://xmlsoft.org/libxml2/libxml2-2.9.4.tar.gz -o ${SOURCE[$LIBRARY]%/*}/libxml2-2.9.4.tar.gz; pushd ${SOURCE[$LIBRARY]%/*}; tar -xzf libxml2-2.9.4.tar.gz; mv libxml2-2.9.4 ${SOURCE[$LIBRARY]}; popd;'
 

--- a/machines/fzj/jureca/cpu.sh
+++ b/machines/fzj/jureca/cpu.sh
@@ -1,4 +1,4 @@
-BASE=$HOME/USQCD/jureca/cpu
+BASE=$PROJECT/USQCD/jureca/cpu
 
 HOST=x86_64-linux-gnu
 

--- a/machines/fzj/jureca/gpu.sh
+++ b/machines/fzj/jureca/gpu.sh
@@ -1,14 +1,13 @@
-BASE=$WORK/USQCD/jureca/gpu
+BASE=$PROJECT/USQCD/jureca/gpu
 GPUS=1
 HOST=x86_64-linux-gnu
 
-module load GCC/5.5.0 MVAPICH2/2.3a-GDR HDF5/1.8.20 FFTW/3.3.7
-module load CUDA/9.1.85
-module load CMake/3.11.1
+module purge
+module load GCC/7.3.0 MVAPICH2/2.3-GDR HDF5/1.8.20 FFTW/3.3.8 CUDA/9.2.88 CMake/3.13.0
 
 DIR[SOURCE]=$HOME/USQCD/jureca/source
-INSTALL[hdf5]=/usr/local/software/jureca/Stages/2018a/software/HDF5/1.8.20-gpsmpi-2018a
-INSTALL[fftw]=/usr/local/software/jureca/Stages/2018a/software/FFTW/3.3.7-gpsmpi-2018a
+INSTALL[hdf5]=/usr/local/software/jureca/Stages/2018b/software/HDF5/1.8.20-gpsmpi-2018b
+INSTALL[fftw]=/usr/local/software/jureca/Stages/2018b/software/FFTW/3.3.8-gpsmpi-2018b
 
 export HOST=x86_64-linux-gnu
 export GPU_ARCH=sm_30


### PR DESCRIPTION
Update machine files for current software stage of JURECA (2018b).
The GPU build is currently not working but that seems to be a deeper problem than just the machine file.